### PR TITLE
Wait for postgres to come up before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,11 @@ jobs:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
-        
+
+      - run:
+          name: wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
       # run tests!
       # this example uses Django's built-in test-runner
       # other common Python testing frameworks include pytest and nose


### PR DESCRIPTION
Some CI runs were failing due to trouble connecting to the database. It's not clear whether this fixes the issue, but it passed four test runs in a row, so maybe that counts for something: https://circleci.com/gh/BAMRU-Tech/workflows/bamru_net/tree/bugfix%2Fcircleci-postgres

Reference https://circleci.com/docs/2.0/databases/#using-dockerize-to-wait-for-dependencies