### PR TITLE
Navbar tweaks

### DIFF
--- a/main/templates/base_generic.html
+++ b/main/templates/base_generic.html
@@ -15,7 +15,7 @@
             media="all" rel="stylesheet">
       {% bootstrap_css %}
     {% endblock css %}
-    <title>{% block title %}Create Event{% endblock title %}</title>
+    <title>{% block title %}BAMRU.net{% endblock title %}</title>
   </head>
 
 

--- a/main/templates/navbar.html
+++ b/main/templates/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-light bg-light fixed-top">
 
-  <a class="navbar-brand" href="#"><i class="fa fa-area-chart"></i>BAMRU.net</a>
+  <a class="navbar-brand" href="/"><i class="fa fa-area-chart"></i> BAMRU.net</a>
 
   {# Hamburger icon for collapsed menu #}
   <button class="navbar-toggler" type="button"
@@ -12,7 +12,7 @@
     <ul class="navbar-nav ml-auto">
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="eventDropdown" data-toggle="dropdown">
-          <i class="fa fa-calendar-check-o"></i>Event
+          <i class="fa fa-calendar-check-o"></i> Event
         </a>
         <div class="dropdown-menu">
           <a class="dropdown-item" href="{% url 'event_add' %}"> 
@@ -32,7 +32,7 @@
       </li>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" id="navbarDropdown" data-toggle="dropdown">
-          <i class="fa fa-user"></i>Team
+          <i class="fa fa-users"></i> Team
         </a>
         <div class="dropdown-menu">
           <a class="dropdown-item" href="{% url 'member_index' %}">
@@ -55,14 +55,14 @@
       </li>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" id="navbarDropdown" data-toggle="dropdown">
-          <i class="fa fa-book"></i>Library
+          <i class="fa fa-book"></i> Library
         </a>
         <div class="dropdown-menu">
           <a class="dropdown-item disabled" href="#">
             <i class="fa fa-file"></i>
             SMCSO Contacts
           </a>
-          <a class="dropdown-item" href="{% url 'reports_index' %}"">
+          <a class="dropdown-item" href="{% url 'reports_index' %}">
             <i class="fa fa-file"></i>
             Reports
           </a>
@@ -90,7 +90,7 @@
       </li>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle disabled" id="navbarDropdown" data-toggle="dropdown">
-          <i class="fa fa-bolt"></i>Action
+          <i class="fa fa-bolt"></i> Action
         </a>
         <div class="dropdown-menu">
           <a class="dropdown-item" href="/zcst/initiate_callout">
@@ -111,17 +111,20 @@
           </a>
         </div>
       </li>
+      {% if request.user.is_authenticated %}
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" id="navbarDropdown" data-toggle="dropdown">
-            <i class="fa fa-user-circle"></i>{{ request.user }}
+            <i class="fa fa-user-circle"></i> {{ request.user }}
         </a>
         <div class="dropdown-menu">
-          {% if request.user.is_authenticated %}
+          <a class="dropdown-item" href="{% url 'member_detail' request.user.id %}">
+            <i class="fa fa-user"></i>
+            Profile
+          </a>
           <a class="dropdown-item" href="{% url 'message:message_inbox' request.user.id%}">
             <i class="fa fa-inbox"></i>
             Inbox (n)
           </a>
-          {% endif %}
           <a class="dropdown-item" href="{% url 'available_edit' %}">
             <i class="fa fa-calendar-times-o"></i>
             My availability
@@ -130,7 +133,7 @@
             <i class="fa fa-calendar-check-o"></i>
             DO availability
           </a>
-          <a class="dropdown-item disabled" href="#">
+          <a class="dropdown-item" href="{% url 'member_certs' request.user.id %}">
             <i class="fa fa-certificate"></i>
             Certifications
           </a>
@@ -144,6 +147,7 @@
           </a>
         </div>
       </li>
+      {% endif %}
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
 - Set default page title back to "BAMRU.net" (not "Create Event").
 - "BAMRU.net" link goes to the home page, in anticipation of there
   being something useful there.
 - Add spaces so that the navbar icons aren't squished against the
   corresponding text.
 - Omit the user navbar dropdown if the user is not logged in.
 - Link "My Certifications" to the certs viewer.
 - Add a "Profile" link in the user dropdown.
 - Change "Team" icon to fa-users instead of fa-user, so we can use
   fa-user for the "Profile" link without visual conflict.
 - Fix extra quote added in #16 :(