### PR TITLE
Add API for member availability

### DIFF
--- a/bamru_net/urls.py
+++ b/bamru_net/urls.py
@@ -30,6 +30,7 @@ router.register(r'members', views.MemberViewSet)
 router.register(r'member_certs', views.MemberCertViewSet, base_name='member')
 router.register(r'certs', views.CertViewSet)
 router.register(r'availability', views.UnavailableViewSet)
+router.register(r'member_availability', views.MemberUnavailableViewSet, base_name='member')
 
 urlpatterns = [
     path('', views.IndexView.as_view()),

--- a/main/serializers.py
+++ b/main/serializers.py
@@ -17,6 +17,29 @@ class UnavailableSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('id', 'url', 'member', 'start_on', 'end_on', 'comment', )
 
 
+class BareUnavailableSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Unavailable
+        fields = ('id', 'member', 'start_on', 'end_on', 'comment', )
+
+
+class MemberUnavailableSerializer(serializers.HyperlinkedModelSerializer):
+    def __init__(self, *args, **kwargs):
+        self._unavailable_filter_kwargs = kwargs.pop('unavailable_filter_kwargs', {})
+        super().__init__(*args, **kwargs)
+
+    busy = serializers.SerializerMethodField()
+    def get_busy(self, member):
+        busy = member.unavailable_set.all()
+        busy = busy.filter(**self._unavailable_filter_kwargs)
+        return BareUnavailableSerializer(busy, context=self.context, many=True).data
+
+    class Meta:
+        model = Member
+        read_only_fields = ('full_name', 'rank', 'rank_order')
+        fields = ('id', 'url', 'busy') + read_only_fields
+
+
 class CertSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Cert


### PR DESCRIPTION
Busy periods can be filtered with the `date_range_start` and `date_range_end` query parameters. For example, a request with `?date_range_start=2018-09-01&date_range_end=2018-09-30` will return only busy periods that include at least one day of September 2018.