### PR TITLE
Support legacy wiki SSO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,11 @@ jobs:
 
             CELERY_BROKER_URL: 'amqp://bnet:bnet_pass@localhost:5672/bnet'
 
+            WIKI_BASE_URL: ''
+            WIKI_SSH_DEST: ''
+            WIKI_SSH_KEY: ''
+            WIKI_AUTH_DIR: ''
+
 
       - store_artifacts:
           path: test-reports

--- a/bamru_net/settings.py
+++ b/bamru_net/settings.py
@@ -185,6 +185,12 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 # Add a five-minute timeout to all Celery tasks.
 CELERYD_TASK_SOFT_TIME_LIMIT = 300
 
+WIKI_BASE_URL = os.environ['WIKI_BASE_URL']
+WIKI_SSH_DEST = os.environ['WIKI_SSH_DEST']
+WIKI_SSH_KEY = os.environ['WIKI_SSH_KEY']
+WIKI_AUTH_DIR = os.environ['WIKI_AUTH_DIR']
+
+
 from django.utils.log import DEFAULT_LOGGING
 LOG_ROOT = os.environ['LOG_ROOT']
 LOGGING_CONFIG = None

--- a/bamru_net/urls.py
+++ b/bamru_net/urls.py
@@ -80,4 +80,6 @@ urlpatterns = [
     path('reports/roster/BAMRU-roster.csv', views.ReportRosterCsvView.as_view()),
     path('reports/roster/BAMRU-roster.vcf', views.ReportRosterVcfView.as_view()),
     path('reports/roster/BAMRU-<str:roster_type>', views.ReportRosterView.as_view()),
+
+    path('home/wiki', views.LegacyWikiSsoView.as_view()),
 ]

--- a/deploy/template/dot_env.j2
+++ b/deploy/template/dot_env.j2
@@ -30,3 +30,9 @@ export MAILGUN_API_KEY='{{ mailgun_api_key }}'
 export MAILGUN_EMAIL_FROM='{{ mailgun_email_from }}'
 
 export CELERY_BROKER_URL='{{ celery_broker_url }}'
+
+# TODO: wire this up
+export WIKI_BASE_URL=''
+export WIKI_SSH_DEST=''
+export WIKI_SSH_KEY=''
+export WIKI_AUTH_DIR=''

--- a/main/views/__init__.py
+++ b/main/views/__init__.py
@@ -1,6 +1,7 @@
 from .api_views import *
 from .do_views import *
 from .event_views import *
+from .legacy_views import *
 from .main_views import *
 from .member_views import *
 from .report_views import *

--- a/main/views/legacy_views.py
+++ b/main/views/legacy_views.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponseRedirect
+from django.views import View
+
+import os
+import subprocess
+
+
+class LegacyWikiSsoView(LoginRequiredMixin, View):
+    def wiki_username(self, user):
+        return user.full_name.replace(' ', '.')
+
+    def get(self, request):
+        path = request.GET.get('wiki_path', '/')
+        path = path.split('?')[0]
+        wiki_username = self.wiki_username(request.user)
+        auth_file = os.path.join(settings.WIKI_AUTH_DIR, wiki_username)
+        with open('/dev/null', 'r') as devnull:
+            subprocess.check_call(['/usr/bin/env'], stdin=devnull, env={})
+            subprocess.check_call([
+                '/usr/bin/ssh',
+                '-o', 'BatchMode=yes',  # fail rather than hanging at a prompt
+                '-o', 'StrictHostKeyChecking=no',
+                '-i', settings.WIKI_SSH_KEY,
+                settings.WIKI_SSH_DEST,
+                'touch', auth_file], stdin=devnull, env={})
+        return HttpResponseRedirect('{}{}?username={}'.format(settings.WIKI_BASE_URL, path, wiki_username))


### PR DESCRIPTION
Post launch, we'll want to switch to something like OAuth2.

This doesn't include deployment configuration, only empty placeholders
in the environment file.