### PR TITLE
Fix member list telephone links on iOS (#402)

### DIFF
--- a/main/templates/base_generic.html
+++ b/main/templates/base_generic.html
@@ -24,6 +24,8 @@
     {# bootstrap_css, needs https #}
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">    {% endblock css %}
     <title>{% block title %}BAMRU.net{% endblock title %}</title>
+
+    <meta name="format-detection" content="telephone=no">
   </head>
 
   <body>


### PR DESCRIPTION
I'm not entirely sure why this works; it seems like there's a bad
interaction between our links and iOS's telephone number detection
(and possibly datatables?).

Reference:
https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html