### PR TITLE
Disable responsive layout on DO planning page.

### DIFF
--- a/main/templates/do_plan.html
+++ b/main/templates/do_plan.html
@@ -55,7 +55,7 @@
 $(document).ready(function() {
     $('#dTbl').DataTable( {
         dom: "Bfrtip",
-        responsive: true,
+        responsive: false,
         paging: false,
         info: false,
         order: [[ 0, "asc" ]],


### PR DESCRIPTION
This was a user request.  We do not want to be missing columns.