### PR TITLE
Delete old backups before uploading newest backup to gdrive

### DIFF
--- a/deploy/template/db.cron.j2
+++ b/deploy/template/db.cron.j2
@@ -10,14 +10,14 @@ OUTDIR=/home/{{ app_user }}/backup
 sudo -u postgres pg_dump {{ db_name }} --compress=5 --file=$FILE
 mv $FILE $OUTDIR
 
-# Upload backup to gdrive
-/usr/local/bin/rclone --config /home/{{ app_user }}/.rclone.conf copy ${OUTDIR}/$FILENAME gdrive:{{ gdrive_remote_dir }}/backup
-
 # Delete old versions (>1w, except 1 per day)
 find $OUTDIR -ctime +7 -not -name '*--23*' -delete
 
 # Delete old versions (>1m, except 1 per 10 days)
 find $OUTDIR -ctime +31 -not -name '*1--23*' -delete
+
+# Upload backup to gdrive
+/usr/local/bin/rclone --config /home/{{ app_user }}/.rclone.conf copy ${OUTDIR}/$FILENAME gdrive:{{ gdrive_remote_dir }}/backup
 
 # Ping success webhook
 wget -q {{ db_backup_status_webhook }} -O /dev/null


### PR DESCRIPTION
This way upload failures do not prevent cleanup of old backups (which causes
the disk to fill up).