### PR TITLE
Reuse database connection for up to 10 minutes

### DIFF
--- a/bamru_net/settings.py
+++ b/bamru_net/settings.py
@@ -124,6 +124,7 @@ DATABASES = {
         'USER': os.environ['DJANGO_DB_USER'],
         'PASSWORD': os.environ['DJANGO_DB_PASS'],
         'HOST': os.environ['DJANGO_DB_HOST'],
+        'CONN_MAX_AGE': 600,
     }
 }
 


### PR DESCRIPTION
By default, django does not reuse database connections. This adds startup
overhead for every request, especially when running in Azure App Services where
the database is not local.