### PR TITLE
Include guests and alums when prefetching members with availability status.

### DIFF
--- a/main/models/member.py
+++ b/main/models/member.py
@@ -262,7 +262,7 @@ class Member(AbstractBaseUser, PermissionsMixin, BaseModel):
 
     @classmethod
     def prefetch_unavailable(cls, name='member_set'):
-        return Prefetch(name, Member.annotate_unavailable(cls.members))
+        return Prefetch(name, Member.annotate_unavailable(cls.objects))
 
     @classmethod
     def annotate_unavailable(cls, qs):


### PR DESCRIPTION
I noticed this as a problem with event member lists; it probably surfaced in
other places as well (the message details view comes to mind).