### PR TITLE
Only show one option on RSVP confirmation page.

### DIFF
--- a/bamru_net/urls.py
+++ b/bamru_net/urls.py
@@ -107,7 +107,7 @@ urlpatterns = [
 
     
     # Message Webhook and Responses
-    path('unauth_rsvp/<slug:token>/', views.unauth_rsvp, name='unauth_rsvp'),
+    path('unauth_rsvp/<slug:token>/<slug:rsvp>/', views.unauth_rsvp, name='unauth_rsvp'),
     path('webhooks/anymail/', include('anymail.urls')),
     path('webhooks/sms_callback/', views.sms_callback, name='sms_callback'),
     path('webhooks/sms/', views.sms, name='sms'),

--- a/main/models/message.py
+++ b/main/models/message.py
@@ -52,9 +52,12 @@ class RsvpTemplate(BasePositionModel):
     def __str__(self):
         return self.name
 
-    def html(self, base_url):
-        yn = ''.join(['<p><a href="{}?rsvp={}">{}</a></p>'
-                      .format(base_url, yn, prompt)
+    def html(self, unauth_rsvp_token):
+        yn = ''.join(['<p><a href="http://{}{}">{}</a></p>'
+                      .format(settings.HOSTNAME,
+                              reverse('unauth_rsvp',
+                                      args=[unauth_rsvp_token, yn]),
+                              prompt)
                       for yn, prompt in
                       (('yes', self.yes_prompt), ('no', self.no_prompt))])
         if APPEND_RSVP_TEMPLATE:
@@ -137,10 +140,7 @@ class Message(BaseModel):
         html_body = ''
         html_body += '<h3>Message:</h3><p>{}</p>'.format(self.text)
         if self.rsvp_template:
-            url = 'http://{}{}'.format(settings.HOSTNAME,
-                                       reverse('unauth_rsvp',
-                                               args=[unauth_rsvp_token]))
-            html_body += self.rsvp_template.html(url)
+            html_body += self.rsvp_template.html(unauth_rsvp_token)
         if self.period:
             url = 'http://{}{}'.format(settings.HOSTNAME,
                                        self.period.event.get_absolute_url())

--- a/main/templates/unauth_rsvp.html
+++ b/main/templates/unauth_rsvp.html
@@ -1,56 +1,18 @@
 {% extends 'base_generic.html' %}
 
-{% block css %}
-{{ block.super }}
-<style>
-#rsvps .button {
-  border: none;
-  color: white;
-  padding: 15px 32px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-}
-.button_yes {background-color: #4CAF50;} /* Green */
-.button_no {background-color: #f44336;} /* Red */
-</style>
-{% endblock css %}
-
-
 {% block content %}
 
 <div id="rsvps">
 <p>
-  RSVP for
+  Confirm RSVP for
   <a href="{{ distribution.message.period.event.get_absolute_url }}">
     {{ distribution.message.period }}</a>
 </p>
 
-<p>
-  <button class="button button_yes" type="button" data-btn="yes">
-    Yes: {{ distribution.message.rsvp_template.yes_prompt }}
-  </button>
-  <button class="button button_no" type="button" data-btn="no">
-    No: {{ distribution.message.rsvp_template.no_prompt }}
-  </button>
-</p>
+<form method="POST">
+  <input type='hidden' name='rsvp' value='{{rsvp}}' />
+  <input type="submit" value="{{rsvp}}: {% if rsvp == 'yes' %}{{ distribution.message.rsvp_template.yes_prompt }}{% else %}{{ distribution.message.rsvp_template.no_prompt }}{% endif %}"/>
+</form>
 </div>
-
-<script>
-$(document).ready(function(){
-
-  $('#rsvps').on('click','button', function (evt) {
-    $.post(window.location,
-    {
-      rsvp: $(this).data('btn'),
-    },
-    function(data,status){
-      alert(data);
-    });
-  });
-});
-</script>
-
 
 {% endblock content %}

--- a/main/tests/test_message.py
+++ b/main/tests/test_message.py
@@ -65,10 +65,11 @@ class OutgoingEmailTestCase(TestCase):
             period=self.period).exists())
 
         # First link should be Yes
-        url = self.follow_link(html, 0)
+        url_yes = self.follow_link(html, 0)
+        url_no = self.follow_link(html, 1)
 
         # The button on that page would POST yes
-        response = self.c.post(url, {'rsvp': 'yes'})
+        response = self.c.post(url_yes, {'rsvp': 'yes'})
         self.assertEqual(response.status_code, 200)
 
         # Check that member is added to the event
@@ -77,7 +78,7 @@ class OutgoingEmailTestCase(TestCase):
             period=self.period).exists())
 
         # POST no
-        response = self.c.post(url, {'rsvp': 'no'})
+        response = self.c.post(url_no, {'rsvp': 'no'})
         self.assertEqual(response.status_code, 200)
 
         # Check that member is removed from the event


### PR DESCRIPTION
This should prevent pre-caching from following the wrong option.