### PR TITLE
Bump pycryptodomex version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -57,7 +57,7 @@ psycopg2-binary==2.8.6
 pyasn1==0.4.4
 pyasn1-modules==0.2.2
 pycparser==2.18
-pycryptodomex==3.7.0
+pycryptodomex==3.16.0
 PyExecJS==1.5.1
 pyjwkest==1.4.0
 PyJWT==2.4.0


### PR DESCRIPTION
v3.7.0 seems to be causing /openid/token to crash with a TypeError: object of type 'filter' has no len().