### PR TITLE
Set name, left, returned to always display

### DIFF
--- a/main/templates/base_generic.html
+++ b/main/templates/base_generic.html
@@ -123,7 +123,7 @@
             console.log(eMsg);
             return '00/00/0000';
         }
-        return r[2] + '/' + r[3] + '/' + r[1]
+        return r[2] + '/' + r[3] + '/' + r[1].slice(-2)
     }
 
     function DateBE( date, offset=0 ) {

--- a/main/templates/event_detail.html
+++ b/main/templates/event_detail.html
@@ -325,7 +325,7 @@ $(document).ready( function() {
               orderable: false, type: ['readonly', 'hidden' ],
               className: 'noVis'
             },
-            { data: 'name', title: 'Name', responsivePriority: 1,
+            { data: 'name', title: 'Name', className: 'all',
               type: 'readonly', width: '45%',
               render: function(data, type, row, meta) {
                   if (type == 'display') {
@@ -360,7 +360,7 @@ $(document).ready( function() {
             },
             { data: 'status_order', type: ['readonly', 'hidden'],
               visible: false, className: 'noVis', },
-            { data: 'en_route_date', title: 'Left', responsivePriority: 2,
+            { data: 'en_route_date', title: 'Left', className: 'all',
               type: ['date', 'allowMultiSelect'], width: '25%',
               render: function (d, t, r, m) {
                   return RenderDateTime(d, t, r, m, 'en_route_time') },
@@ -368,7 +368,7 @@ $(document).ready( function() {
             { data: 'en_route_time', title: 'at', type: ['time', 'allowMultiSelect' ],
               visible: false, className: 'noVis'
             },
-            { data: 'return_home_date', title: 'Returned', responsivePriority: 2,
+            { data: 'return_home_date', title: 'Returned', className: 'all',
               type: ['date', 'allowMultiSelect'], width: '25%',
               render: function (d, t, r, m) {
                   return RenderDateTime(d, t, r, m, 'return_home_time') },


### PR DESCRIPTION
@ctaylor451 - Used the all class as described here: https://datatables.net/extensions/responsive/classes#Special-classes

Per feedback from a few members on not being able to see all their desired information in mobile view off the event details.

I also made a relatively significant to display 2 digit years instead of 4 digit years.  I have plans to tackle [#175](https://github.com/BAMRU-Tech/bamru_net/issues/175) and more visual space will help.