### PR TITLE
Disable tracing

### DIFF
--- a/deploy/gunicorn.config.py
+++ b/deploy/gunicorn.config.py
@@ -4,4 +4,4 @@ from bamru_net.tracing import setup_tracing
 def post_fork(server, worker):
     server.log.info("Worker spawned (pid: %s)", worker.pid)
 
-    setup_tracing()
+    # setup_tracing()

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,7 @@ from bamru_net.tracing import setup_tracing
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bamru_net.settings")
 
-    setup_tracing()
+    # setup_tracing()
 
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
Django-Q is having issues. We see a lot of errors from opentelemetry. Maybe they are causing the problem somehow? Let's see if this helps.