### PR TITLE
Update child process handling

### DIFF
--- a/deploy/azure_startup.sh
+++ b/deploy/azure_startup.sh
@@ -5,6 +5,7 @@ cd $APP_PATH
 python manage.py migrate
 
 python manage.py qcluster &
+QCLUSTER_PID=$!
 
 gunicorn \
   --workers 4 \
@@ -17,3 +18,24 @@ gunicorn \
   bamru_net.wsgi \
   -c deploy/gunicorn.config.py \
   &
+GUNICORN_PID=$!
+
+# Wait until either process exits
+wait -n $QCLUSTER_PID $GUNICORN_PID
+
+EXIT_CODE=$? # This should be the exit code of whichever process ends first
+
+EXIT_MSG="$(date "+%Y-%m-%d %H:%M:%S") exiting with wait exit code ${EXIT_CODE}"
+
+# Check and append which process ended
+EXIT_MSG="${EXIT_MSG}$(
+  kill -0 $QCLUSTER_PID 2>/dev/null || echo -n ' Qcluster ended'
+)"
+EXIT_MSG="${EXIT_MSG}$(
+  kill -0 $GUNICORN_PID 2>/dev/null || echo -n ' Gunicorn ended'
+)"
+echo $EXIT_MSG
+
+# SIGTERM this shell and all its child processes
+# This way we don't leave one process running alone if the other one dies
+kill -- -$$

--- a/deploy/azure_startup.sh
+++ b/deploy/azure_startup.sh
@@ -6,4 +6,14 @@ python manage.py migrate
 
 python manage.py qcluster &
 
-gunicorn --workers 4 --threads 1 --timeout 30 --access-logfile '/home/LogFiles/gunicorn-access.log' --error-logfile '/home/LogFiles/gunicorn-error.log' --bind=0.0.0.0:8000 --chdir=. bamru_net.wsgi -c deploy/gunicorn.config.py
+gunicorn \
+  --workers 4 \
+  --threads 1 \
+  --timeout 30 \
+  --access-logfile '/home/LogFiles/gunicorn-access.log' \
+  --error-logfile '/home/LogFiles/gunicorn-error.log' \
+  --bind=0.0.0.0:8000 \
+  --chdir=. \
+  bamru_net.wsgi \
+  -c deploy/gunicorn.config.py \
+  &


### PR DESCRIPTION
### What?
Add azure_startup.sh ends the process if the children die
Add logging for timestamp, exit code and which process ended
Update azure_startup.sh to break up a long line

### Why?
This is to allow us to better understand if one of the spawned processes fails before the app is terminated.
It also should cause the hosting service to restart the app if one of the children dies.