### PR TITLE
Configure django storage using STORAGES variable

### DIFF
--- a/bamru_net/settings.py
+++ b/bamru_net/settings.py
@@ -228,8 +228,14 @@ AZURE_MEDIA_CONTAINER = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
 AZURE_STATIC_CONTAINER = os.environ.get('AZURE_STATIC_CONTAINER', 'static')
 
 if AZURE_STORAGE_KEY:
-    DEFAULT_FILE_STORAGE = 'bamru_net.backend.AzureMediaStorage'
-    #STATICFILES_STORAGE = 'bamru_net.backend.AzureStaticStorage'
+    STORAGES = {
+        'default': {
+            'BACKEND': 'bamru_net.backend.AzureMediaStorage',
+        },
+        'staticfiles': {
+            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage', # django default
+        },
+    }
 
     # AZURE_CUSTOM_DOMAIN = '{}.azureedge.net'.format(AZURE_STORAGE_ACCOUNT_NAME)  # CDN URL
     AZURE_CUSTOM_DOMAIN = '{}.blob.core.windows.net'.format(AZURE_STORAGE_ACCOUNT_NAME)  # Files URL

--- a/requirements/opentelemetry.txt
+++ b/requirements/opentelemetry.txt
@@ -20,5 +20,4 @@ opentelemetry-proto==1.11.1
 opentelemetry-sdk==1.11.1
 opentelemetry-semantic-conventions==0.30b1
 opentelemetry-util-http==0.30b1
-typing_extensions==4.2.0
 wrapt==1.14.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,8 +6,9 @@ aiosignal==1.4.0
 arrow==1.4.0
 asgiref==3.10.0
 attrs==25.4.0
-azure-common==1.1.27
-azure-storage-blob==2.1.0
+azure-core==1.36.0
+azure-common==1.1.28
+azure-storage-blob==12.27.1
 azure-storage-common==2.1.0
 Babel==2.9.1
 bcrypt==5.0.0
@@ -49,6 +50,7 @@ google-auth-httplib2==0.2.0
 googleapis-common-protos==1.56.3
 httplib2==0.19.0
 idna==2.6
+isodate==0.7.2
 itypes==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
@@ -92,6 +94,7 @@ soupsieve==2.3.2.post1
 sqlparse==0.5.3
 stylus==0.1.2
 twilio==9.8.4
+typing_extensions==4.15.0
 tzdata==2025.2
 uritemplate==4.2.0
 urllib3==2.5.0


### PR DESCRIPTION
DEFAULT_FILE_STORAGE was deprecated in Django 4.2 and removed in 5.1. We never saw a deprecation warning since we skipped over all those versions.

Upgrades of azure packages were also required.